### PR TITLE
Update runner-ex4.yml

### DIFF
--- a/.sauce/runner-ex4.yml
+++ b/.sauce/runner-ex4.yml
@@ -26,12 +26,12 @@ suites:
     testOptions:
       class: ["com.swaglabsmobileapp.LoginTest#noPasswordLogin"]
     devices:
-      - name: Samsung_Galaxy_S20_real
+      - id: Samsung_Galaxy_S20_real
   - name: "Sauce Labs Espresso Tests from Example 4 - noMatchLogin"
     testOptions:
       class: ["com.swaglabsmobileapp.LoginTest#noMatchLogin"]
     devices:
-      - name: Samsung_Galaxy_S10_Plus_real
+      - id: Samsung_Galaxy_S10_Plus_real
 
 # Controls what artifacts to fetch when the suite on Sauce Cloud has finished.
 artifacts:


### PR DESCRIPTION
From Thiago:
the concept behind the 2 different ways of selecting a device are:
dynamic: you can use a regex to match multiple devices (useful for when the customer wants, for example, ANY iPhone X: name: iPhone X)
hardcoded (static): you can only match a single device with the exact ID it has (useful for when the customer wants a really specific device: id: iPhone_X_us_real1 , commonly used by customers with private devices)

@wswebcreation - can you review and merge?